### PR TITLE
Suppression du titre "Transformation"

### DIFF
--- a/Ce qui nous réunit.md
+++ b/Ce qui nous réunit.md
@@ -2,9 +2,7 @@
 
 ATTENTION : Ceci est un brouillon !
 
-## Transformation
-
-### Philosophie
+## Philosophie
 
 * Nous partageons les valeurs et principes du manifeste agile
 * Nous défendons ces valeurs et pincipes chez nos clients
@@ -12,7 +10,7 @@ ATTENTION : Ceci est un brouillon !
 * Nous considérons que l'agilité n'est pas la réponse à tout 
 * Nous refusons de forcer les personne à devenir Agile
 
-### En vrac
+## En vrac
 
 * Pragmatic
 * Transformation émérgente
@@ -22,7 +20,7 @@ ATTENTION : Ceci est un brouillon !
 * DevOps
 * Software Crafts(wo)manship
 
-### Approches d'accompagnement
+## Approches d'accompagnement
 
 * Nous sommes agiles dans la façon de mener nos accompagnements
 * Nous cherchons d'abord à véhiculer la philosophie agile avant les méthodologies ou les pratiques


### PR DESCRIPTION
Ce titre était resté du moment où on pensait distinguer des idées propres aux transfo et d'autres plutôt à l'opérationnel, mais après on a fait autre chose et on n'a pas nettoyé ça.